### PR TITLE
extend example and add some comments

### DIFF
--- a/examples/lwt/dune
+++ b/examples/lwt/dune
@@ -1,3 +1,3 @@
 (executable
  (name readme)
- (libraries archi-lwt lwt.unix))
+ (libraries archi-lwt lwt.unix caqti caqti-lwt caqti-driver-postgresql logs logs.lwt uri))

--- a/examples/lwt/readme.ml
+++ b/examples/lwt/readme.ml
@@ -1,22 +1,65 @@
 open Lwt.Infix
 open Archi_lwt
 
+let src = Logs.Src.create "example" ~doc:"logs from program entrypoint"
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+type config =
+  { db_host : string
+  ; db_port : int
+  ; webserver_port : int
+  }
+
+(* Reading a config file doesn't need to be started or stopped, for this we use
+   'Component.identity'. Imagine these arguments being read in by use of
+   'Cmdliner.Cmd.eval_value' or equivalent. *)
+let config =
+  Component.identity
+  @@ { db_host = "127.0.0.1"; db_port = 5432; webserver_port = 3000 }
+
 module Database = struct
-  type db = { handle : int }
+  let start () conf =
+    let connection_url =
+      Printf.sprintf
+        "postgresql://user:password@%s:%d/db_name?sslmode=allow&connect_timeout=15"
+        conf.db_host
+        conf.db_port
+    in
+    Log.info (fun m ->
+        m "Connecting to database: %s:%d" conf.db_host conf.db_port);
+    let pool =
+      match
+        Caqti_lwt.connect_pool ~max_size:4 (Uri.of_string connection_url)
+      with
+      | Ok pool -> pool
+      | Error err ->
+        Log.err (fun m -> m "%s" (Caqti_error.show err));
+        failwith (Caqti_error.show err)
+    in
+    Lwt_result.return
+      (pool : (Caqti_lwt.connection, Caqti_error.connect) Caqti_lwt.Pool.t)
 
-  let start () =
-    Format.eprintf "Started DB.@.";
-    Lwt_result.return { handle = 42 }
+  (* The 'stop' function takes a single argument of the type returned by
+     'start' *)
+  let stop pool =
+    Log.info (fun m -> m "Draining database connection pool");
+    Caqti_lwt.Pool.drain pool
 
-  let stop _db = Lwt_io.eprintlf "Stopped DB.%!"
-  let component = Component.make ~start ~stop
+  (* Each dependency adds an additional positional argument to the 'start'
+     function *)
+  let component = Component.using ~start ~stop ~dependencies:[ config ]
 end
 
 module WebServer = struct
   type t = Lwt_io.server
 
-  let start () _db : (t, [ `Msg of string ]) Lwt_result.t =
-    let listen_address = Unix.(ADDR_INET (inet_addr_loopback, 3000)) in
+  (* 'start' takes dependencies as positional arguments. The type is whatever
+     the depencency 'start' function returns. *)
+  let start () _db conf : (t, [ `Msg of string ]) Lwt_result.t =
+    let listen_address =
+      Unix.(ADDR_INET (inet_addr_loopback, conf.webserver_port))
+    in
     Lwt_io.establish_server_with_client_address listen_address (fun _ _ ->
         Lwt_io.printlf "Client connected.%!")
     >>= fun server ->
@@ -28,7 +71,7 @@ module WebServer = struct
     Lwt_io.eprintlf "Stopped server.%!"
 
   let component =
-    Component.using ~start ~stop ~dependencies:[ Database.component ]
+    Component.using ~start ~stop ~dependencies:[ Database.component; config ]
 end
 
 let system =


### PR DESCRIPTION
First of all thanks a ton for creating `archi` @anmonteiro!

I've extended the example and added some comments. I didn't find it entirely straight forward to use so hopefully this can save someone else a few minutes!

I hope it is acceptable that I pulled in a few more modules into the example to make it more "complete".

I removed the Database type as I was struggling to appease the compiler. In my use outside of this example where I pass the pool on to functions outside of the `start` function the compiler wouldn't accept it. I'm sure this is doable and I'm lacking knowledge and experience with OCaml so would appreciate some feedback on the PR!